### PR TITLE
Fix error when plugin fails with CSS node without `selector` attr

### DIFF
--- a/lib/helpers.es6
+++ b/lib/helpers.es6
@@ -18,8 +18,8 @@ export function extendStyle(htmlNode, cssNode) {
 export function sortCssNodesBySpecificity(nodes) {
     // Sort CSS nodes by specificity (ascending): div - .foo - #bar
     return nodes.sort((a, b) => {
-        a = getSpecificity(a.selector);
-        b = getSpecificity(b.selector);
+        a = typeof a.selector == 'string' ? getSpecificity(a.selector) : 0;
+        b = typeof b.selector == 'string' ? getSpecificity(b.selector) : 0;
 
         if (a > b) {
             return 1;

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -36,6 +36,13 @@ describe('Plugin', () => {
             expect(html).toBe(expectedHtmlWithStyle);
         });
     });
+
+    it('should properly process any other nodes', () => {
+        var css = '@media {}/* comment */.test {color: red;}';
+        var html = '<div class="test">olala</div>';
+        var expectedHtml = '<div class="test" style="color: red">olala</div>';
+        return initPlugin(css, html).then(html => expect(html).toBe(expectedHtml));
+    });
 });
 
 


### PR DESCRIPTION
Fixes error when plugin fails with CSS node without selector. To reproduce try this code:

``` js
var posthtml = require('posthtml');
    css = '/* comment */div { color: red }';

posthtml([require('posthtml-inline-css')(css)])
    .process('<div style="font-size: 14px">Hello!</div>')
    .then(function (result) {
        console.log(result.html);
    })
    .catch(function (e) {
        console.log(e.stack);
    });
```

You will get `TypeError: Cannot read property 'split' of undefined` from specificity.js. PR fixes this error.
